### PR TITLE
Ring axis no longer relative

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1127,7 +1127,7 @@
   //#define SHAPING_MENU                // Add a menu to the LCD to set shaping parameters.
 #endif
 
-#define AXIS_RELATIVE_MODES { false, false, false, true, false }
+#define AXIS_RELATIVE_MODES { false, false, false, false, false }
 
 // Add a Duplicate option for well-separated conjoined nozzles
 //#define MULTI_NOZZLE_DUPLICATION


### PR DESCRIPTION
The Relative ring axis was causing the ring to spin wildly as the gcode generated assumed it was sending absolute positions - therefore positions ~180 degrees resulted in a full half turn per instruction.